### PR TITLE
maint: CI github actions sur node 12.X seulement

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
closes #1 