### PR TITLE
Flush completely the end to end database before run

### DIFF
--- a/frontend/end_to_end/end_to_end_server.js
+++ b/frontend/end_to_end/end_to_end_server.js
@@ -5,7 +5,10 @@ module.exports = {
     const databaseFile = "sqlite:///end_to_end_db.sqlite3";
     const backendPath = "../backend/maprochainerecette";
     const djangoEnv = `cd ${backendPath} && DATABASE_URL=${databaseFile}`;
-    execute(`${djangoEnv} pipenv run python manage.py flush --noinput`, true);
+    execute(
+      `${djangoEnv} pipenv run python manage.py reset_db --noinput`,
+      true
+    );
     execute(`${djangoEnv} pipenv run python manage.py makemigrations`, true);
     execute(
       `${djangoEnv} pipenv run python manage.py migrate --run-syncdb`,


### PR DESCRIPTION
`reset_db` command flushes completely the dababase, including the tables' structure, contrary to the `flush` django command we use currently. Thanks to this, any change made to the end to end database in the previous runs will be removed.